### PR TITLE
feat: Add swipe-to-edit functionality for list items

### DIFF
--- a/AlmostOut/AlmostOut/Models/PriceGuidance.swift
+++ b/AlmostOut/AlmostOut/Models/PriceGuidance.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PriceGuidance: Codable {
+struct PriceGuidance: Codable, Equatable {
     let type: PriceType
     let exactAmount: Double?
     let maxAmount: Double?

--- a/AlmostOut/AlmostOut/ViewModels/EditItemViewModel.swift
+++ b/AlmostOut/AlmostOut/ViewModels/EditItemViewModel.swift
@@ -1,0 +1,130 @@
+//
+//  EditItemViewModel.swift
+//  AlmostOut
+//
+//  Created by Miles Ranisavljevic on 8/26/25.
+//
+
+import SwiftUI
+
+@MainActor
+class EditItemViewModel: ObservableObject {
+    @Published var name = ""
+    @Published var note = ""
+    @Published var quantity = ""
+    @Published var priority: ListItem.Priority = .normal
+    @Published var selectedCategory: ItemCategory?
+    @Published var priceGuidance: PriceGuidance?
+    @Published var selectedImages: [UIImage] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    
+    private let listId: String
+    private let originalItem: ListItem
+    private let databaseService: DatabaseServiceProtocol
+    private let storageService: StorageServiceProtocol
+    private let authService: AuthServiceProtocol
+    
+    init(
+        listId: String,
+        item: ListItem,
+        databaseService: DatabaseServiceProtocol = FirestoreService(),
+        storageService: StorageServiceProtocol = FirebaseStorageService(),
+        authService: AuthServiceProtocol = FirebaseAuthService()
+    ) {
+        self.listId = listId
+        self.originalItem = item
+        self.databaseService = databaseService
+        self.storageService = storageService
+        self.authService = authService
+        
+        // Pre-populate fields with existing item data
+        self.name = item.name
+        self.note = item.note ?? ""
+        self.quantity = item.quantity ?? ""
+        self.priority = item.priority
+        self.selectedCategory = item.category
+        self.priceGuidance = item.priceGuidance
+        // Note: We're not loading existing images into selectedImages for now
+        // as that would require converting from URLs to UIImages
+    }
+    
+    var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    
+    var hasChanges: Bool {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedQuantity = quantity.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        return trimmedName != originalItem.name ||
+               (trimmedNote.isEmpty ? nil : trimmedNote) != originalItem.note ||
+               (trimmedQuantity.isEmpty ? nil : trimmedQuantity) != originalItem.quantity ||
+               priority != originalItem.priority ||
+               selectedCategory != originalItem.category ||
+               priceGuidance != originalItem.priceGuidance ||
+               !selectedImages.isEmpty
+    }
+    
+    func updateItem() async -> Bool {
+        guard isValid, hasChanges else { return false }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            // Upload new images if any
+            var allImages = originalItem.images
+            if !selectedImages.isEmpty {
+                var uploadedImages: [ItemImage] = []
+                
+                for image in selectedImages {
+                    if let compressedData = ImageProcessor.compressImage(image) {
+                        let uploadedImage = try await storageService.uploadImage(
+                            compressedData,
+                            for: originalItem.id ?? "",
+                            in: listId,
+                            type: .reference
+                        )
+                        uploadedImages.append(uploadedImage)
+                    }
+                }
+                
+                allImages.append(contentsOf: uploadedImages)
+            }
+            
+            // Create updated item
+            let updatedItem = ListItem(
+                id: originalItem.id,
+                name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+                note: note.isEmpty ? nil : note.trimmingCharacters(in: .whitespacesAndNewlines),
+                quantity: quantity.isEmpty ? nil : quantity.trimmingCharacters(in: .whitespacesAndNewlines),
+                priority: priority,
+                category: selectedCategory,
+                addedBy: originalItem.addedBy,
+                addedByName: originalItem.addedByName,
+                createdAt: originalItem.createdAt,
+                updatedAt: Date(),
+                isCompleted: originalItem.isCompleted,
+                completedBy: originalItem.completedBy,
+                completedByName: originalItem.completedByName,
+                completedAt: originalItem.completedAt,
+                priceGuidance: priceGuidance,
+                images: allImages,
+                actualPrice: originalItem.actualPrice,
+                storeLocation: originalItem.storeLocation
+            )
+            
+            try await databaseService.updateItem(updatedItem, in: listId)
+            
+            isLoading = false
+            return true
+            
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+            return false
+        }
+    }
+}

--- a/AlmostOut/AlmostOut/Views/EditItem/EditItemView.swift
+++ b/AlmostOut/AlmostOut/Views/EditItem/EditItemView.swift
@@ -1,0 +1,128 @@
+//
+//  EditItemView.swift
+//  AlmostOut
+//
+//  Created by Miles Ranisavljevic on 8/26/25.
+//
+
+import PhotosUI
+import SwiftUI
+
+struct EditItemView: View {
+    let listId: String
+    let item: ListItem
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var viewModel: EditItemViewModel
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    @State private var showingPriceGuidance = false
+    
+    init(listId: String, item: ListItem) {
+        self.listId = listId
+        self.item = item
+        self._viewModel = StateObject(wrappedValue: EditItemViewModel(listId: listId, item: item))
+    }
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Item Details") {
+                    TextField("Item Name", text: $viewModel.name)
+                    TextField("Notes (Optional)", text: $viewModel.note, axis: .vertical)
+                        .lineLimit(3)
+                    TextField("Quantity (Optional)", text: $viewModel.quantity)
+                }
+                
+                Section("Priority") {
+                    Picker("Priority", selection: $viewModel.priority) {
+                        ForEach(ListItem.Priority.allCases, id: \.self) { priority in
+                            Text(priority.displayName).tag(priority)
+                        }
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+                
+                Section("Category") {
+                    CategoryPickerView(selectedCategory: $viewModel.selectedCategory)
+                }
+                
+                Section("Price Guidance") {
+                    Button("Set Price Guidance") {
+                        showingPriceGuidance = true
+                    }
+                    
+                    if let priceGuidance = viewModel.priceGuidance {
+                        Text(priceGuidance.displayText)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                
+                Section("Photos") {
+                    PhotosPickerView(selectedImages: $viewModel.selectedImages)
+                    
+                    if !item.images.isEmpty {
+                        Text("Existing photos will be preserved")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle("Edit Item")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        Task {
+                            let success = await viewModel.updateItem()
+                            if success {
+                                dismiss()
+                            }
+                        }
+                    }
+                    .disabled(!viewModel.isValid || !viewModel.hasChanges || viewModel.isLoading)
+                }
+            }
+            .sheet(isPresented: $showingPriceGuidance) {
+                PriceGuidanceView(priceGuidance: $viewModel.priceGuidance)
+            }
+        }
+    }
+}
+
+#Preview("Edit Item View") {
+    EditItemView(
+        listId: "preview-list",
+        item: ListItem(
+            id: "preview-item",
+            name: "Sample Item",
+            note: "Sample note",
+            quantity: "2",
+            priority: .normal,
+            category: nil,
+            addedBy: "user1",
+            addedByName: "User One",
+            createdAt: Date(),
+            updatedAt: Date(),
+            isCompleted: false,
+            completedBy: nil,
+            completedByName: nil,
+            completedAt: nil,
+            priceGuidance: nil,
+            images: [],
+            actualPrice: nil,
+            storeLocation: nil
+        )
+    )
+}

--- a/AlmostOut/AlmostOut/Views/ListDetail/ItemRowView.swift
+++ b/AlmostOut/AlmostOut/Views/ListDetail/ItemRowView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ItemRowView: View {
     let item: ListItem
     let onToggleComplete: () -> Void
+    let onEdit: () -> Void
     
     var body: some View {
         HStack(spacing: 12) {
@@ -65,6 +66,12 @@ struct ItemRowView: View {
             Spacer()
         }
         .padding(.vertical, 4)
+        .swipeActions(edge: .trailing) {
+            Button("Edit") {
+                onEdit()
+            }
+            .tint(.blue)
+        }
     }
     
     private func priorityIcon(_ priority: ListItem.Priority) -> String {

--- a/AlmostOut/AlmostOut/Views/ListDetail/ListDetailView.swift
+++ b/AlmostOut/AlmostOut/Views/ListDetail/ListDetailView.swift
@@ -12,6 +12,7 @@ struct ListDetailView: View {
     @StateObject private var viewModel: ListDetailViewModel
     @State private var showingAddItem = false
     @State private var showingFilters = false
+    @State private var editingItem: ListItem?
     
     init(listId: String) {
         self.listId = listId
@@ -27,11 +28,13 @@ struct ListDetailView: View {
             } else {
                 List {
                     ForEach(viewModel.filteredItems) { item in
-                        ItemRowView(item: item) {
+                        ItemRowView(item: item, onToggleComplete: {
                             Task {
                                 await viewModel.toggleItemCompletion(item)
                             }
-                        }
+                        }, onEdit: {
+                            editingItem = item
+                        })
                     }
                     .onDelete(perform: deleteItems)
                 }
@@ -59,6 +62,9 @@ struct ListDetailView: View {
         }
         .sheet(isPresented: $showingFilters) {
             FilterView(viewModel: viewModel)
+        }
+        .sheet(item: $editingItem) { item in
+            EditItemView(listId: listId, item: item)
         }
         .searchable(text: $viewModel.searchText, prompt: "Search items...")
     }

--- a/AlmostOut/AlmostOutTests/EditItemViewModelTests.swift
+++ b/AlmostOut/AlmostOutTests/EditItemViewModelTests.swift
@@ -1,0 +1,303 @@
+//
+//  EditItemViewModelTests.swift
+//  AlmostOut
+//
+//  Created by Miles Ranisavljevic on 8/26/25.
+//
+
+import XCTest
+@testable import AlmostOut
+
+@MainActor
+class EditItemViewModelTests: XCTestCase {
+    var viewModel: EditItemViewModel!
+    var mockDatabaseService: MockDatabaseService!
+    var mockStorageService: MockStorageService!
+    var mockAuthService: MockAuthService!
+    var testItem: ListItem!
+    
+    override func setUp() {
+        super.setUp()
+        mockDatabaseService = MockDatabaseService()
+        mockStorageService = MockStorageService()
+        mockAuthService = MockAuthService()
+        
+        testItem = createTestItem()
+        
+        viewModel = EditItemViewModel(
+            listId: "test-list",
+            item: testItem,
+            databaseService: mockDatabaseService,
+            storageService: mockStorageService,
+            authService: mockAuthService
+        )
+    }
+    
+    override func tearDown() {
+        viewModel = nil
+        mockDatabaseService = nil
+        mockStorageService = nil
+        mockAuthService = nil
+        testItem = nil
+        super.tearDown()
+    }
+    
+    func testInitializationWithExistingItem() {
+        // Then - ViewModel should be pre-populated with existing item data
+        XCTAssertEqual(viewModel.name, "Test Item")
+        XCTAssertEqual(viewModel.note, "Test note")
+        XCTAssertEqual(viewModel.quantity, "2")
+        XCTAssertEqual(viewModel.priority, .high)
+        XCTAssertEqual(viewModel.selectedCategory?.name, "dairy")
+        XCTAssertEqual(viewModel.priceGuidance?.type, .maxBudget)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+    
+    func testIsValidWithValidName() {
+        // Given - Valid name
+        viewModel.name = "Valid Item Name"
+        
+        // Then
+        XCTAssertTrue(viewModel.isValid)
+    }
+    
+    func testIsValidWithEmptyName() {
+        // Given - Empty name
+        viewModel.name = ""
+        
+        // Then
+        XCTAssertFalse(viewModel.isValid)
+    }
+    
+    func testIsValidWithWhitespaceOnlyName() {
+        // Given - Whitespace only name
+        viewModel.name = "   \t\n  "
+        
+        // Then
+        XCTAssertFalse(viewModel.isValid)
+    }
+    
+    func testHasChangesWhenNoChanges() {
+        // Given - No changes made to the item
+        // When - Check if there are changes
+        // Then
+        XCTAssertFalse(viewModel.hasChanges, "Should have no changes when nothing is modified")
+    }
+    
+    func testHasChangesWhenNameChanged() {
+        // Given - Change the name
+        viewModel.name = "Updated Item Name"
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when name is modified")
+    }
+    
+    func testHasChangesWhenNoteChanged() {
+        // Given - Change the note
+        viewModel.note = "Updated note"
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when note is modified")
+    }
+    
+    func testHasChangesWhenQuantityChanged() {
+        // Given - Change the quantity
+        viewModel.quantity = "5"
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when quantity is modified")
+    }
+    
+    func testHasChangesWhenPriorityChanged() {
+        // Given - Change the priority
+        viewModel.priority = .urgent
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when priority is modified")
+    }
+    
+    func testHasChangesWhenCategoryChanged() {
+        // Given - Change the category
+        viewModel.selectedCategory = ItemCategory(name: "bakery", isCustom: false, scope: .global)
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when category is modified")
+    }
+    
+    func testHasChangesWhenPriceGuidanceChanged() {
+        // Given - Change the price guidance
+        viewModel.priceGuidance = PriceGuidance(
+            type: .qualityPreference,
+            exactAmount: nil,
+            maxAmount: nil,
+            rangeMin: nil,
+            rangeMax: nil,
+            qualityLevel: .premium
+        )
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when price guidance is modified")
+    }
+    
+    func testHasChangesWhenImagesAdded() {
+        // Given - Add new images
+        let testImage = UIImage(systemName: "photo") ?? UIImage()
+        viewModel.selectedImages = [testImage]
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when new images are added")
+    }
+    
+    func testHasChangesWithNoteRemovedWhenOriginallyHadNote() {
+        // Given - Remove the note (set to empty)
+        viewModel.note = ""
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when note is removed")
+    }
+    
+    func testHasChangesWithQuantityRemovedWhenOriginallyHadQuantity() {
+        // Given - Remove the quantity (set to empty)
+        viewModel.quantity = ""
+        
+        // When - Check if there are changes
+        // Then
+        XCTAssertTrue(viewModel.hasChanges, "Should detect changes when quantity is removed")
+    }
+    
+    func testUpdateItemSuccessWithChanges() async {
+        // Given - Make changes to the item
+        viewModel.name = "Updated Item"
+        viewModel.note = "Updated note"
+        
+        mockAuthService.currentUser = User(
+            uid: "test-uid",
+            email: "test@example.com",
+            displayName: "Test User",
+            profileImageUrl: nil,
+            createdAt: Date(),
+            updatedAt: Date(),
+            preferences: User.UserPreferences(),
+            fcmTokens: []
+        )
+        
+        // When - Update the item
+        let success = await viewModel.updateItem()
+        
+        // Then
+        XCTAssertTrue(success, "Should successfully update the item")
+        XCTAssertFalse(viewModel.isLoading, "Should not be loading after completion")
+        XCTAssertNil(viewModel.errorMessage, "Should not have an error message")
+    }
+    
+    func testUpdateItemFailsWithoutChanges() async {
+        // Given - No changes made to the item
+        
+        // When - Attempt to update the item
+        let success = await viewModel.updateItem()
+        
+        // Then
+        XCTAssertFalse(success, "Should not update when there are no changes")
+        XCTAssertFalse(viewModel.isLoading, "Should not be loading")
+    }
+    
+    func testUpdateItemFailsWithInvalidName() async {
+        // Given - Invalid name (empty)
+        viewModel.name = ""
+        
+        // When - Attempt to update the item
+        let success = await viewModel.updateItem()
+        
+        // Then
+        XCTAssertFalse(success, "Should not update with invalid name")
+        XCTAssertFalse(viewModel.isLoading, "Should not be loading")
+    }
+    
+    func testUpdateItemWithImageUpload() async {
+        // Given - Add new images and make other changes
+        let testImage = UIImage(systemName: "photo") ?? UIImage()
+        viewModel.selectedImages = [testImage]
+        viewModel.name = "Updated with Image"
+        
+        mockAuthService.currentUser = User(
+            uid: "test-uid",
+            email: "test@example.com",
+            displayName: "Test User",
+            profileImageUrl: nil,
+            createdAt: Date(),
+            updatedAt: Date(),
+            preferences: User.UserPreferences(),
+            fcmTokens: []
+        )
+        
+        // When - Update the item
+        let success = await viewModel.updateItem()
+        
+        // Then
+        XCTAssertTrue(success, "Should successfully update the item with images")
+        XCTAssertFalse(viewModel.isLoading, "Should not be loading after completion")
+        XCTAssertNil(viewModel.errorMessage, "Should not have an error message")
+    }
+    
+    func testLoadingStatesDuringUpdate() async {
+        // Given - Make changes
+        viewModel.name = "Updated Item"
+        
+        mockAuthService.currentUser = User(
+            uid: "test-uid",
+            email: "test@example.com",
+            displayName: "Test User",
+            profileImageUrl: nil,
+            createdAt: Date(),
+            updatedAt: Date(),
+            preferences: User.UserPreferences(),
+            fcmTokens: []
+        )
+        
+        // When - Start update (we can't easily test the loading state mid-update with current setup)
+        let success = await viewModel.updateItem()
+        
+        // Then - After completion
+        XCTAssertTrue(success, "Should successfully update")
+        XCTAssertFalse(viewModel.isLoading, "Should not be loading after completion")
+    }
+    
+    private func createTestItem() -> ListItem {
+        return ListItem(
+            id: "test-item-id",
+            name: "Test Item",
+            note: "Test note",
+            quantity: "2",
+            priority: .high,
+            category: ItemCategory(name: "dairy", isCustom: false, scope: .global),
+            addedBy: "test-uid",
+            addedByName: "Test User",
+            createdAt: Date(),
+            updatedAt: Date(),
+            isCompleted: false,
+            completedBy: nil,
+            completedByName: nil,
+            completedAt: nil,
+            priceGuidance: PriceGuidance(
+                type: .maxBudget,
+                exactAmount: nil,
+                maxAmount: 10.0,
+                rangeMin: nil,
+                rangeMax: nil,
+                qualityLevel: nil
+            ),
+            images: [],
+            actualPrice: nil,
+            storeLocation: nil
+        )
+    }
+}


### PR DESCRIPTION
- Add swipe gesture on list items to reveal edit button
- Implement EditItemViewModel with change detection and update logic
- Create EditItemView with pre-populated form fields from existing item
- Update ItemRowView to support swipe actions with blue edit button
- Update ListDetailView to handle edit navigation via sheet presentation
- Make PriceGuidance conform to Equatable for change detection
- Add comprehensive EditItemViewModelTests covering all functionality
- Preserve existing item data while allowing selective editing
- Support adding new images while preserving existing photos

🤖 Generated with [Claude Code](https://claude.ai/code)